### PR TITLE
feat!: replace SEP const parameter with runtime value

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,7 +138,6 @@ impl<'a> Csv<'a> {
         }
     }
 
-impl<'a> Csv<'a> {
     /// Create a wrapper iterator that buffers the cells per row.
     ///
     /// # Example

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,7 +137,6 @@ impl<'a> Csv<'a> {
             state: IterState::Cell(0),
         }
     }
-}
 
 impl<'a> Csv<'a> {
     /// Create a wrapper iterator that buffers the cells per row.


### PR DESCRIPTION
This PR replaces the `SEP` const generic parameter of the `Csv` type.

Having `SEP` as a const generic parameter made the interface hard to use, while providing no performance benefits. Therefore this PR replaces it with a runtime value.